### PR TITLE
Add device restart api and command

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,7 +12,15 @@ This is known to work with:
 The provided CLI tool supports the following commands:
 
 + `get-hosts`: retrieves the connected devices and generates a hosts file.
-Permissions: "view".
+Required permissions: "View".
++ `device restart`: restarts a device managed by the UDM, e.g. a wireless access
+point. Required permissions: "Site Admin".
+
+See the `--help` output of individual commands for full usage details, e.g.:
+
+```sh
+$ udm-pro-api-client device restart --help
+```
 
 ## Configuration
 

--- a/cmd/udm-pro-api-client/commands/device/cmd.go
+++ b/cmd/udm-pro-api-client/commands/device/cmd.go
@@ -1,0 +1,17 @@
+package device
+
+import (
+	"github.com/jsumners/udm-pro-api-client/cmd/udm-pro-api-client/internal/app"
+	"github.com/spf13/cobra"
+)
+
+func New(app *app.CliApp) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "device",
+		Short: "Interact with devices known by the UDM.",
+	}
+
+	cmd.AddCommand(NewRestart(app))
+
+	return cmd
+}

--- a/cmd/udm-pro-api-client/commands/device/restart.go
+++ b/cmd/udm-pro-api-client/commands/device/restart.go
@@ -1,0 +1,31 @@
+package device
+
+import (
+	"github.com/MakeNowJust/heredoc"
+	"github.com/jsumners/udm-pro-api-client"
+	"github.com/jsumners/udm-pro-api-client/cmd/udm-pro-api-client/internal/app"
+	"github.com/spf13/cobra"
+)
+
+func NewRestart(app *app.CliApp) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "restart macAddress",
+		Short: "Restart a device.",
+		Long: heredoc.Doc(`
+			Issue a restart command to a device that is managed by the UDM.
+			For example, use this command to restart a wireless access point that
+			is misbehaving.
+		`),
+		Args:    cobra.ExactArgs(1),
+		Example: "device restart 9C:0E:CC:8E:4B:C7",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return run(app.Client, args[0])
+		},
+	}
+
+	return cmd
+}
+
+func run(client *udm.Client, macAddress string) error {
+	return client.RestartDevice(macAddress)
+}

--- a/cmd/udm-pro-api-client/commands/root/root.go
+++ b/cmd/udm-pro-api-client/commands/root/root.go
@@ -1,14 +1,18 @@
 package root
 
 import (
+	"github.com/jsumners/udm-pro-api-client/cmd/udm-pro-api-client/internal/app"
 	"github.com/spf13/cobra"
 )
 
 type InitFn func() error
 
-func New(configFile *string, initFns ...InitFn) *cobra.Command {
+func New(app *app.CliApp, initFns ...InitFn) *cobra.Command {
 	cmd := &cobra.Command{
 		Short: "udm-pro-api-client",
+		// We don't need Cobra to print out the errors for us.
+		// Our app does that by bubbling up errors to the main function.
+		SilenceErrors: true,
 		PersistentPreRunE: func(*cobra.Command, []string) error {
 			for _, initFn := range initFns {
 				err := initFn()
@@ -21,11 +25,19 @@ func New(configFile *string, initFns ...InitFn) *cobra.Command {
 	}
 
 	cmd.PersistentFlags().StringVarP(
-		configFile,
+		&app.ConfigFilePath,
 		"conf-file",
 		"c",
 		"",
 		"Set the file from which configuration will be loaded.",
+	)
+
+	cmd.PersistentFlags().BoolVarP(
+		&app.HttpDebugEnabled,
+		"http-debug",
+		"H",
+		false,
+		"enable verbose printing of HTTP requests",
 	)
 
 	return cmd

--- a/cmd/udm-pro-api-client/internal/app/app.go
+++ b/cmd/udm-pro-api-client/internal/app/app.go
@@ -6,6 +6,8 @@ import (
 )
 
 type CliApp struct {
-	Config *config.Configuration
-	Client *udm.Client
+	ConfigFilePath   string
+	Config           *config.Configuration
+	Client           *udm.Client
+	HttpDebugEnabled bool
 }

--- a/device.go
+++ b/device.go
@@ -1,0 +1,56 @@
+package udm
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+type RestartDevicePayload struct {
+	// MacAddress is used to identify the device that will be restarted.
+	MacAddress string `json:"mac"`
+
+	// RebootType indicates how the device should be rebooted. Known values:
+	// + "soft"
+	RebootType string `json:"reboot_type"`
+
+	// Command to be issued to the device. Known values:
+	// + "restart"
+	Command string `json:"cmd"`
+}
+
+// RestartDevice is used to trigger a device restart for devices that are
+// managed by the UDM, e.g. a wireless access point. "Site Admin" level
+// permissions are needed in order for this operation to work.
+func (client *Client) RestartDevice(macAddress string) error {
+	path := fmt.Sprintf("/proxy/network/api/s/%s/cmd/devmgr", client.hostInfo.Site)
+	payload := RestartDevicePayload{
+		MacAddress: macAddress,
+		RebootType: "soft",
+		Command:    "restart",
+	}
+
+	resp, err := client.resty.R().
+		SetBody(payload).
+		SetHeader("content-type", "application/json").
+		Post(path)
+	if err != nil {
+		return fmt.Errorf("failed to restart device (%s): %w", macAddress, err)
+	}
+
+	if resp.StatusCode() < 200 || resp.StatusCode() > 299 {
+		return errors.New(fmt.Sprintf("http error: %s", resp.Status()))
+	}
+
+	var parsed GenericResponse
+	err = json.Unmarshal(resp.Body(), &parsed)
+	if err != nil {
+		return fmt.Errorf("failed to parse restart response: %w", err)
+	}
+
+	if parsed.Meta.Code == "error" {
+		return errors.New(fmt.Sprintf("api error: %s", parsed.Meta.Message))
+	}
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,8 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
+	github.com/gookit/color v1.5.4 // indirect
+	github.com/gookit/goutil v0.6.15 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
@@ -28,6 +30,7 @@ require (
 	github.com/spf13/cast v1.6.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
+	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8 // indirect
 	golang.org/x/net v0.22.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,10 @@ github.com/go-resty/resty/v2 v2.12.0 h1:rsVL8P90LFvkUYq/V5BTVe203WfRIU4gvcf+yfzJ
 github.com/go-resty/resty/v2 v2.12.0/go.mod h1:o0yGPrkS3lOe1+eFajk6kBW8ScXzwU3hD69/gt2yB/0=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/gookit/color v1.5.4 h1:FZmqs7XOyGgCAxmWyPslpiok1k05wmY3SJTytgvYFs0=
+github.com/gookit/color v1.5.4/go.mod h1:pZJOeOS8DM43rXbp4AZo1n9zCU2qjpcRko0b6/QJi9w=
+github.com/gookit/goutil v0.6.15 h1:mMQ0ElojNZoyPD0eVROk5QXJPh2uKR4g06slgPDF5Jo=
+github.com/gookit/goutil v0.6.15/go.mod h1:qdKdYEHQdEtyH+4fNdQNZfJHhI0jUZzHxQVAV3DaMDY=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -62,6 +66,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
+github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
+github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 // New instantiates a [Client] instance and returns it.
 // The client will need to issue a [Client.Login] before any requests to the API
 // can be issued.
-func New(hostInfo HostInfo) (*Client, error) {
+func New(hostInfo HostInfo, options ...Option) (*Client, error) {
 	client := &Client{
 		hostInfo: hostInfo,
 	}
@@ -19,6 +19,36 @@ func New(hostInfo HostInfo) (*Client, error) {
 	client.resty.SetBaseURL(fmt.Sprintf("https://%s", hostInfo.Address))
 	client.resty.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
 
+	// The UDM utilizes a CSRF token for non-read-only operations. Therefore,
+	// we need to pick up that token on every response.
+	client.resty.OnAfterResponse(func(c *resty.Client, res *resty.Response) error {
+		token := res.Header().Get("X-Csrf-Token")
+		if token == "" {
+			return nil
+		}
+
+		if token != client.csrfToken {
+			client.csrfToken = token
+		}
+
+		return nil
+	})
+
+	// And on every outgoing request, we need to add the CSRF token.
+	client.resty.OnBeforeRequest(func(c *resty.Client, req *resty.Request) error {
+		if client.csrfToken != "" {
+			req.SetHeader("X-Csrf-Token", client.csrfToken)
+		}
+		return nil
+	})
+
+	for _, opt := range options {
+		err := opt(client)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return client, nil
 }
 
@@ -26,8 +56,8 @@ func New(hostInfo HostInfo) (*Client, error) {
 // The instance will be authenticated with the remote UDM server
 // and ready to issue requests. If an issue occurs while authenticating
 // an error will be returned.
-func NewWithLogin(hostInfo HostInfo) (*Client, error) {
-	client, _ := New(hostInfo)
+func NewWithLogin(hostInfo HostInfo, options ...Option) (*Client, error) {
+	client, _ := New(hostInfo, options...)
 
 	err := client.Login()
 	if err != nil {
@@ -37,14 +67,26 @@ func NewWithLogin(hostInfo HostInfo) (*Client, error) {
 	return client, nil
 }
 
+// WithHttpDebug enables verbose printing of all HTTP requests.
+func WithHttpDebug() Option {
+	return func(c *Client) error {
+		c.resty.SetDebug(true)
+		return nil
+	}
+}
+
+type credentials struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
 // Login authenticates against the UDM. This must be done prior to issuing
 // any requests to the API.
 func (client *Client) Login() error {
-	payload := fmt.Sprintf(
-		`{"username":"%s","password":"%s"}`,
-		client.hostInfo.Username,
-		client.hostInfo.Password,
-	)
+	payload := credentials{
+		Username: client.hostInfo.Username,
+		Password: client.hostInfo.Password,
+	}
 
 	resp, err := client.resty.R().
 		SetHeader("content-type", "application/json").

--- a/types.go
+++ b/types.go
@@ -2,6 +2,8 @@ package udm
 
 import "github.com/go-resty/resty/v2"
 
+type Option func(*Client) error
+
 // HostInfo describes the details needed to connect to the desired UDM.
 type HostInfo struct {
 	// Address is the IP address or hostname, e.g. "192.168.1.1" or
@@ -21,8 +23,14 @@ type HostInfo struct {
 }
 
 type Client struct {
-	hostInfo HostInfo
-	resty    resty.Client
+	hostInfo  HostInfo
+	resty     resty.Client
+	csrfToken string
+}
+
+type GenericResponse struct {
+	Meta ResponseMeta `json:"meta"`
+	Data []any        `json:"data"`
 }
 
 // ResponseMeta represents the `meta` property in a UDM API response.


### PR DESCRIPTION
This PR adds a new API method and CLI command for issue device restarts. The API for creating clients has been updated to accept option functions in order to enable HTTP debugging.